### PR TITLE
Update XSD-classes to match XSD

### DIFF
--- a/kontroller/src/main/kotlin/no/ssb/kostra/barn/xsd/KostraLovhjemmelType.kt
+++ b/kontroller/src/main/kotlin/no/ssb/kostra/barn/xsd/KostraLovhjemmelType.kt
@@ -18,8 +18,11 @@ data class KostraLovhjemmelType(
     @field:XmlAttribute(name = "Paragraf", required = true)
     val paragraf: String,
 
-    @field:XmlAttribute(name = "Ledd", required = true)
-    val ledd: String,
+    @field:XmlAttribute(name = "Bokstav")
+    val bokstav: String? = null,
+
+    @field:XmlAttribute(name = "Ledd")
+    val ledd: String? = null,
 
     @field:XmlAttribute(name = "Punktum")
     val punktum: String? = null

--- a/kontroller/src/main/resources/Individ.xsd
+++ b/kontroller/src/main/resources/Individ.xsd
@@ -27,7 +27,7 @@
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-		<xs:attribute name="Fodselsnummer" use="optional">
+		<xs:attribute name="Fodselsnummer">
 			<xs:simpleType>
 				<xs:restriction base="xs:string">
 					<xs:minLength value="11"/>
@@ -36,7 +36,7 @@
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-		<xs:attribute name="DUFnummer" use="optional">
+		<xs:attribute name="DUFnummer">
 			<xs:simpleType>
 				<xs:restriction base="xs:string">
 					<xs:minLength value="12"/>
@@ -45,7 +45,7 @@
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-		<xs:attribute name="Bydelsnummer" use="optional">
+		<xs:attribute name="Bydelsnummer">
 			<xs:annotation>
 				<xs:documentation>2-sifret bydelsnummer for bydelene i Oslo</xs:documentation>
 			</xs:annotation>
@@ -220,8 +220,8 @@ Koder om annet:
 		</xs:sequence>
 		<xs:attribute ref="Id" use="required"/>
 		<xs:attribute ref="StartDato" use="required"/>
-		<xs:attribute ref="SluttDato" use="optional"/>
-		<xs:attribute name="Konklusjon" use="optional">
+		<xs:attribute ref="SluttDato"/>
+		<xs:attribute name="Konklusjon">
 			<xs:annotation>
 				<xs:documentation>Kode for konklusjon av meldingen: 
 1 = Henlagt 
@@ -255,7 +255,7 @@ Koder om annet:
 		</xs:sequence>
 		<xs:attribute ref="Id" use="required"/>
 		<xs:attribute ref="StartDato" use="required"/>
-		<xs:attribute ref="SluttDato" use="optional"/>
+		<xs:attribute ref="SluttDato"/>
 	</xs:complexType>
 	<xs:complexType name="LovhjemmelType">
 		<xs:attribute name="Lov" use="required">
@@ -294,7 +294,7 @@ Koder om annet:
 				</xs:restriction>
 			</xs:simpleType>
 		</xs:attribute>
-		<xs:attribute name="Punktum" use="optional">
+		<xs:attribute name="Punktum">
 			<xs:simpleType>
 				<xs:restriction base="xs:string">
 					<xs:minLength value="0"/>
@@ -491,8 +491,8 @@ Koder om annet:
 		</xs:sequence>
 		<xs:attribute ref="Id" use="required"/>
 		<xs:attribute ref="StartDato" use="required"/>
-		<xs:attribute ref="SluttDato" use="optional"/>
-		<xs:attribute name="Konklusjon" use="optional">
+		<xs:attribute ref="SluttDato"/>
+		<xs:attribute name="Konklusjon">
 			<xs:annotation>
 				<xs:documentation>Kode for konklusjon av undersøkelse:
 1 = Barneverntjenesten fatter vedtak om tiltak 


### PR DESCRIPTION
- [Remove redundant use=optional specification from xsd](https://github.com/statisticsnorway/kostra-kontrollprogram/commit/db72ce96f63bededa8cefa2c7680ec6119d564bb)
- [Update LovhjemmelType to match XSD](https://github.com/statisticsnorway/kostra-kontrollprogram/commit/4bce59fd9a8513305e084077198d98991d50f714)