### PR TITLE
Reverting to previous version of micronaut-test-kotest5

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>io.micronaut.test</groupId>
             <artifactId>micronaut-test-kotest5</artifactId>
-            <version>3.9.2</version>
+            <version>3.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Version 3.9.2 is causing build failures. Reverting back to the previous version.