### PR TITLE
Prune empty lines

### DIFF
--- a/kontroller/src/main/kotlin/no/ssb/kostra/program/KotlinArguments.kt
+++ b/kontroller/src/main/kotlin/no/ssb/kostra/program/KotlinArguments.kt
@@ -29,7 +29,7 @@ data class KotlinArguments(
     }
 
     fun getInputContentAsStringList(delimiter: String = DEFAULT_LINEBREAK_CHAR): List<String> =
-        inputFileContent.split(delimiter).map { it.trim('\r') }
+        inputFileContent.split(delimiter).map { it.trim('\r') }.filter { it.isNotEmpty() }
 
     fun getInputContentAsInputStream(): InputStream = inputFileContent.byteInputStream(Charsets.ISO_8859_1)
 

--- a/kontroller/src/test/kotlin/no/ssb/kostra/program/KotlinArgumentsTest.kt
+++ b/kontroller/src/test/kotlin/no/ssb/kostra/program/KotlinArgumentsTest.kt
@@ -73,10 +73,10 @@ class KotlinArgumentsTest : BehaviorSpec({
     Given("KotlinArguments#getInputContentAsStringList()") {
 
         forAll(
-            row("empty content", "", listOf("")),
+            row("empty content", "", listOf()),
             row("content with new line", "a\nb", listOf("a", "b")),
             row("content with carriage return and new line", "a\r\nb", listOf("a", "b")),
-            row("content with carriage return and new line plus blank line at end", "a\r\nb\n", listOf("a", "b", "")),
+            row("content with carriage return and new line plus blank line at end", "a\r\nb\n", listOf("a", "b")),
         ) { description, content, expectedList ->
             When(description) {
                 val kotlinArguments = KotlinArguments(


### PR DESCRIPTION
Sometimes the file has an empty line in the end. This line with the length of 0 will cause an error in Rule001RecordLength. This fix will prune away empty lines before the validations run.