### PR TITLE
Kostra Regnskap: Revert funksjon 290 and 465

### DIFF
--- a/kontroller/src/main/kotlin/no/ssb/kostra/area/regnskap/kostra/KommuneKostraMain.kt
+++ b/kontroller/src/main/kotlin/no/ssb/kostra/area/regnskap/kostra/KommuneKostraMain.kt
@@ -56,11 +56,11 @@ class KommuneKostraMain(
     )
 
     private val kommuneFinansielleFunksjoner = listOf(
-        "290", "800", "840", "841", "850", "860", "870", "880", "899"
+        "800", "840", "841", "850", "860", "870", "880", "899"
     )
 
     private val fylkeFinansielleFunksjoner = listOf(
-        "465", "800", "840", "841", "860", "870", "880", "899"
+        "800", "840", "841", "860", "870", "880", "899"
     )
 
     private val fylkeskommunaleSbdrOgLaanefondFinansielleFunksjoner = listOf(


### PR DESCRIPTION
Use of funksjon 290 and 465 is hereby reverted